### PR TITLE
New features

### DIFF
--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -13,7 +13,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IUploader)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IClick)
-
+    plugins.implements(plugins.IResourceController, inherit=True)
     # IConfigurer
 
     def update_config(self, config_):
@@ -72,3 +72,28 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
 
     def get_commands(self):
         return [upload_resources]
+
+    # IResourceController
+
+    def before_delete(self, context, resource, resources):
+        # let's get all info about our resource. It somewhere in resources
+        # but if there is some possibility that it isn't(magic?) we have
+        # `else` clause
+        for res in resources:
+            if res["id"] == resource["id"]:
+                break
+        else:
+            return
+        # just ignore simple links
+        if res["url_type"] != "upload":
+            return
+
+        # we don't want to change original item from resources, just in case
+        # someone will use it in another `before_delete`. So, let's copy it
+        # and add `clear_upload` flag
+        res_dict = dict(list(res.items()) + [("clear_upload", True)])
+
+        uploader = self.get_resource_uploader(res_dict)
+
+        # and now uploader removes our file.
+        uploader.upload(resource["id"])

--- a/ckanext/s3filestore/views/resource.py
+++ b/ckanext/s3filestore/views/resource.py
@@ -69,11 +69,17 @@ def resource_download(package_type, id, resource_id, filename=None):
             if preview:
                 url = upload.get_signed_url_to_key(key_path)
             else:
-                params = {
-                    'ResponseContentDisposition':
-                        'attachment; filename=' + filename,
-                }
-                url = upload.get_signed_url_to_key(key_path, params)
+                file_size = upload.find_file_size(filename=key_path)
+                # If a file size is greater than 10MB it should then automatically download the file
+                if file_size >= 10485760:
+                    params = {
+                        'ResponseContentDisposition':
+                            'attachment; filename=' + filename,
+                    }
+                    url = upload.get_signed_url_to_key(key_path, params)
+                else:
+                    url = upload.get_signed_url_to_key(key_path)
+
             return redirect(url)
 
         except ClientError as ex:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-boto3>=1.4.4
-ckantoolkit
+boto3>=1.24.2
+ckantoolkit>=0.0.4


### PR DESCRIPTION
With the plugin the features added were
1. Support for multipart uploads
2. Support to delete resource from S3 after the resource from removed from CKAN
3. If a file is under `10MB` and the url for the resource is pasted into the browser, the user will be taken to the S3 url instead of downloading the file.

**Fix Details:**

For multipart uploads simply used boto3 with ```boto3.resource('s3').upload_fileobj()``` this method support of sending a binary object to S3 and split the file into chunks of 25MB. 
Created the `boto3.s3. TransferConfig` object to support multiple threads to support faster uploads as such it will spin off `10 threads`.
#### Note:  We will decide on the number of threads inside the test environment.

Implemented an additional Interface ```IResourceController``` which allows to capture the click on the delete button.
this allows the capture the resource that is requested to being removed after this we pass the resource to the uploader.upload with the setting of `("clear_upload", True)` and this then allows for the file to be removed from S3.

Added a change to support file sizes < 10MB to be viewed directly inside the browser instead of having it downloaded to the client machine.