### PR TITLE
Support for intelligent tiering

### DIFF
--- a/ckanext/s3filestore/click_commands.py
+++ b/ckanext/s3filestore/click_commands.py
@@ -83,6 +83,7 @@ def upload_resources():
         s3_connection.Object(bucket_name, key) \
             .upload_fileobj(buffered_bytes,
                             ExtraArgs={
+                                'StorageClass': 'INTELLIGENT_TIERING',
                                 'ACL': acl,
                                 'ContentType': mime.from_file(resource_ids_and_paths[resource_id]) or 'text/plain'
                             },

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -137,6 +137,7 @@ class BaseS3Uploader(object):
             s3.Object(self.bucket_name, filepath). \
                 upload_fileobj(upload_file,
                                ExtraArgs={
+                                   'StorageClass': 'INTELLIGENT_TIERING',
                                    'ACL': 'public-read' if make_public else self.acl,
                                    'ContentType': getattr(self, 'mimetype', '') or 'text/plain'
                                },


### PR DESCRIPTION
Added `INTELLIGENT_TIERING`

This will add objects to the bucket with a header `x-amz-storage-class` set to use Intelligent Tiering.
Objects will move to the correct storage class after this is set and will all be managed by S3.