### PR TITLE
presigned url upload with chunking works

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,102 +1,220 @@
-CKAN: The Open Source Data Portal Software
-==========================================
+.. You should enable this project on travis-ci.org and coveralls.io to make
+these badges work. The necessary Travis and Coverage config files have been
+generated for you.
 
-.. image:: https://img.shields.io/badge/license-AGPL-blue.svg?style=flat
-    :target: https://opensource.org/licenses/AGPL-3.0
-    :alt: License
-
-.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat
-    :target: http://docs.ckan.org
-    :alt: Documentation
-.. image:: https://img.shields.io/badge/support-StackOverflow-yellowgreen.svg?style=flat
-    :target: https://stackoverflow.com/questions/tagged/ckan
-    :alt: Support on StackOverflow
-
-.. image:: https://circleci.com/gh/ckan/ckan.svg?style=shield
-    :target: https://circleci.com/gh/ckan/ckan
-    :alt: Build Status
-
-.. image:: https://coveralls.io/repos/github/ckan/ckan/badge.svg?branch=master
-    :target: https://coveralls.io/github/ckan/ckan?branch=master
-    :alt: Coverage Status
-
-.. image:: https://badges.gitter.im/gitterHQ/gitter.svg
-    :target: https://gitter.im/ckan/chat
-    :alt: Chat on Gitter
-
-**CKAN is the world’s leading open-source data portal platform**.
-CKAN makes it easy to publish, share and work with data. It's a data management
-system that provides a powerful platform for cataloging, storing and accessing
-datasets with a rich front-end, full API (for both data and catalog), visualization
-tools and more. Read more at `ckan.org <http://ckan.org/>`_.
+.. image:: https://github.com/keitaroinc/ckanext-s3filestore/workflows/CI/badge.svg
+    :target: https://github.com/keitaroinc/ckanext-s3filestore/actions
 
 
+.. image:: https://coveralls.io/repos/github/keitaroinc/ckanext-s3filestore/badge.svg?branch=main
+     :target: https://coveralls.io/github/keitaroinc/ckanext-s3filestore?branch=main
+
+.. image:: https://img.shields.io/badge/python-3.8-blue.svg
+    :target: https://www.python.org/downloads/release/python-384/
+
+.. image:: https://img.shields.io/pypi/v/ckanext-s3filestore
+    :target: https://pypi.org/project/ckanext-s3filestore
+
+
+
+===================
+ckanext-s3filestore
+===================
+
+Supports chunked uploads direct to S3, bypassing buffering content into CKAN.
+
+Default::
+
+     ckanext.s3filestore.max_file_upload_size_in_bytes = 10737418240
+     ckanext.s3filestore.max_file_part_size_in_bytes = 4294967296
+
+
+
+------------
+Note:
+------------
+AWS Supports a maximum of 5GB in one chunk and a max of 1000 pre-signed urls.
+
+Use Amazon S3 as a filestore for resources.
+
+As chunked files are to be stitched together using the (finish_multipart) CKAN action after a successful upload to S3 is complete,
+
+Server session timeout is to be considered as a factor to decide upper thresholds for file size and chunk size
+
+
+------------
+Requirements
+------------
+
+Requires CKAN 2.9+
+
+When installing this extension on CKAN versions prior 2.9 please use `ckan-2.8 <https://github.com/keitaroinc/ckanext-s3filestore/tree/ckan-2.8>`_ branch.
+
+------------
 Installation
 ------------
 
-See the `CKAN Documentation <http://docs.ckan.org>`_ for installation instructions.
+.. Add any additional install steps to the list below.
+For example installing any non-Python dependencies or adding any required
+config settings.
+
+To install ckanext-s3filestore:
+
+1. Activate your CKAN virtual environment, for example::
+
+     . /usr/lib/ckan/default/bin/activate
+
+2. Install the ckanext-s3filestore Python package into your virtual environment::
+
+     pip install ckanext-s3filestore
+
+3. Add ``s3filestore`` to the ``ckan.plugins`` setting in your CKAN
+   config file (by default the config file is located at
+   ``/etc/ckan/default/ckan.ini``).
+
+4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu::
+
+     sudo service apache2 reload
 
 
-Support
--------
-If you need help with CKAN or want to ask a question, use either the
-`ckan-dev`_ mailing list, the `CKAN chat on Gitter`_, or the `CKAN tag on Stack Overflow`_ (try
-searching the Stack Overflow and ckan-dev `archives`_ for an answer to your
-question first).
+---------------
+Config Settings
+---------------
 
-If you've found a bug in CKAN, open a new issue on CKAN's `GitHub Issues`_ (try
-searching first to see if there's already an issue for your bug).
+Required::
 
-If you find a potential security vulnerability please email security@ckan.org,
-rather than creating a public issue on GitHub.
+    ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
+    ckanext.s3filestore.region_name= region-name
+    ckanext.s3filestore.signature_version = s3v4
 
-.. _CKAN tag on Stack Overflow: http://stackoverflow.com/questions/tagged/ckan
-.. _archives: https://groups.google.com/a/ckan.org/g/ckan-dev
-.. _GitHub Issues: https://github.com/ckan/ckan/issues
-.. _CKAN chat on Gitter: https://gitter.im/ckan/chat
+Conditional::
 
+    ckanext.s3filestore.aws_access_key_id = Your-Access-Key-ID
+    ckanext.s3filestore.aws_secret_access_key = Your-Secret-Access-Key
 
-Contributing to CKAN
---------------------
+    Or:
 
-For contributing to CKAN or its documentation, see
-`CONTRIBUTING <https://github.com/ckan/ckan/blob/master/CONTRIBUTING.md>`_.
+    ckanext.s3filestore.aws_use_ami_role = true
 
-Mailing List
-~~~~~~~~~~~~
+Optional::
 
-Subscribe to the `ckan-dev`_ mailing list to receive news about upcoming releases and
-future plans as well as questions and discussions about CKAN development, deployment, etc.
+    # An optional path to prepend to keys
+    ckanext.s3filestore.aws_storage_path = my-site-name
 
-Community Chat
-~~~~~~~~~~~~~~
+    # An optional setting to fallback to filesystem for downloads
+    ckanext.s3filestore.filesystem_download_fallback = true
+    # The ckan storage path option must also be set correctly for the fallback to work
+    ckan.storage_path = path/to/storage/directory
 
-If you want to talk about CKAN development say hi to the CKAN developers and members of
-the CKAN community on the public `CKAN chat on Gitter`_. Gitter is free and open-source;
-you can sign in with your GitHub, GitLab, or Twitter account.
+    # An optional setting to change the acl of the uploaded files. Default public-read.
+    ckanext.s3filestore.acl = private
 
-The logs for the old `#ckan`_ IRC channel (2014 to 2018) can be found here:
-https://github.com/ckan/irc-logs.
+    # An optional setting to specify which addressing style to use. This controls whether the bucket name is in the hostname or is part of the URL. Default auto.
+    ckanext.s3filestore.addressing_style = path
 
-Wiki
-~~~~
+    # Set this parameter only if you want to use Minio as a filestore service instead of S3.
+    ckanext.s3filestore.host_name = http://minio-service.com
 
-If you've figured out how to do something with CKAN and want to document it for
-others, make a new page on the `CKAN wiki`_ and tell us about it on the
-ckan-dev mailing list or on Gitter.
+    # To mask the S3 endpoint with your own domain/endpoint when serving URLs to end users.
+    # This endpoint should be capable of serving S3 objects as if it were an actual bucket.
+    # The real S3 endpoint will still be used for uploading files.
+    ckanext.s3filestore.download_proxy = https://example.com/my-bucket
 
-.. _ckan-dev: https://groups.google.com/a/ckan.org/forum/#!forum/ckan-dev
-.. _#ckan: http://webchat.freenode.net/?channels=ckan
-.. _CKAN Wiki: https://github.com/ckan/ckan/wiki
-.. _CKAN chat on Gitter: https://gitter.im/ckan/chat
+    # Defines how long a signed URL is valid (default 1 hour).
+    ckanext.s3filestore.signed_url_expiry = 3600
+
+    # Don't check for access on each startup
+    ckanext.s3filestore.check_access_on_startup = false
 
 
-Copying and License
--------------------
+-----------------
+CLI
+-----------------
 
-This material is copyright (c) 2006-2018 Open Knowledge Foundation and contributors.
+To upload all local resources located in `ckan.storage_path` location dir to the configured S3 bucket use::
 
-It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
-whose full text may be found at:
+    ckan -c /etc/ckan/default/ckan.ini s3-upload
 
-http://www.fsf.org/licensing/licenses/agpl-3.0.html
+
+------------------------
+Development Installation
+------------------------
+
+To install ckanext-s3filestore for development, activate your CKAN virtualenv and
+do::
+
+    git clone https://github.com/okfn/ckanext-s3filestore.git
+    cd ckanext-s3filestore
+    python setup.py develop
+    pip install -r dev-requirements.txt
+    pip install -r requirements.txt
+
+
+-----------------
+Running the Tests
+-----------------
+
+To run the tests, do::
+
+    nosetests --ckan --nologcapture --with-pylons=test.ini
+
+To run the tests and produce a coverage report, first make sure you have
+coverage installed in your virtualenv (``pip install coverage``) then run::
+
+    nosetests --ckan --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.s3filestore --cover-inclusive --cover-erase --cover-tests
+
+
+---------------------------------------
+Registering ckanext-s3filestore on PyPI
+---------------------------------------
+
+ckanext-s3filestore should be available on PyPI as
+https://pypi.python.org/pypi/ckanext-s3filestore. If that link doesn't work, then
+you can register the project on PyPI for the first time by following these
+steps:
+
+1. Create a source distribution of the project::
+
+     python setup.py sdist
+
+2. Register the project::
+
+     python setup.py register
+
+3. Upload the source distribution to PyPI::
+
+     python setup.py sdist upload
+
+4. Tag the first release of the project on GitHub with the version number from
+   the ``setup.py`` file. For example if the version number in ``setup.py`` is
+   0.0.1 then do::
+
+       git tag 0.0.1
+       git push --tags
+
+
+----------------------------------------------
+Releasing a New Version of ckanext-s3filestore
+----------------------------------------------
+
+ckanext-s3filestore is available on PyPI as https://pypi.python.org/pypi/ckanext-s3filestore.
+To publish a new version to PyPI follow these steps:
+
+1. Update the version number in the ``setup.py`` file.
+   See `PEP 440 <http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers>`_
+   for how to choose version numbers.
+
+2. Create a source distribution of the new version::
+
+     python setup.py sdist
+
+3. Upload the source distribution to PyPI::
+
+     python setup.py sdist upload
+
+4. Tag the new release of the project on GitHub with the version number from
+   the ``setup.py`` file. For example if the version number in ``setup.py`` is
+   0.0.2 then do::
+
+       git tag 0.0.2
+       git push --tags

--- a/README.rst
+++ b/README.rst
@@ -1,204 +1,102 @@
-.. You should enable this project on travis-ci.org and coveralls.io to make
-   these badges work. The necessary Travis and Coverage config files have been
-   generated for you.
+CKAN: The Open Source Data Portal Software
+==========================================
 
-.. image:: https://github.com/keitaroinc/ckanext-s3filestore/workflows/CI/badge.svg
-    :target: https://github.com/keitaroinc/ckanext-s3filestore/actions
+.. image:: https://img.shields.io/badge/license-AGPL-blue.svg?style=flat
+    :target: https://opensource.org/licenses/AGPL-3.0
+    :alt: License
+
+.. image:: https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat
+    :target: http://docs.ckan.org
+    :alt: Documentation
+.. image:: https://img.shields.io/badge/support-StackOverflow-yellowgreen.svg?style=flat
+    :target: https://stackoverflow.com/questions/tagged/ckan
+    :alt: Support on StackOverflow
+
+.. image:: https://circleci.com/gh/ckan/ckan.svg?style=shield
+    :target: https://circleci.com/gh/ckan/ckan
+    :alt: Build Status
+
+.. image:: https://coveralls.io/repos/github/ckan/ckan/badge.svg?branch=master
+    :target: https://coveralls.io/github/ckan/ckan?branch=master
+    :alt: Coverage Status
+
+.. image:: https://badges.gitter.im/gitterHQ/gitter.svg
+    :target: https://gitter.im/ckan/chat
+    :alt: Chat on Gitter
+
+**CKAN is the world’s leading open-source data portal platform**.
+CKAN makes it easy to publish, share and work with data. It's a data management
+system that provides a powerful platform for cataloging, storing and accessing
+datasets with a rich front-end, full API (for both data and catalog), visualization
+tools and more. Read more at `ckan.org <http://ckan.org/>`_.
 
 
-.. image:: https://coveralls.io/repos/github/keitaroinc/ckanext-s3filestore/badge.svg?branch=main
-     :target: https://coveralls.io/github/keitaroinc/ckanext-s3filestore?branch=main
-
-.. image:: https://img.shields.io/badge/python-3.8-blue.svg
-    :target: https://www.python.org/downloads/release/python-384/
-
-.. image:: https://img.shields.io/pypi/v/ckanext-s3filestore
-    :target: https://pypi.org/project/ckanext-s3filestore
-
-
-
-===================
-ckanext-s3filestore
-===================
-
-.. Put a description of your extension here:
-
-Use Amazon S3 or Minio<https://minio.io/> as a filestore for resources.
-
-
-------------
-Requirements
-------------
-
-Requires CKAN 2.9+
-
-When installing this extension on CKAN versions prior 2.9 please use `ckan-2.8 <https://github.com/keitaroinc/ckanext-s3filestore/tree/ckan-2.8>`_ branch.
-
-------------
 Installation
 ------------
 
-.. Add any additional install steps to the list below.
-   For example installing any non-Python dependencies or adding any required
-   config settings.
-
-To install ckanext-s3filestore:
-
-1. Activate your CKAN virtual environment, for example::
-
-     . /usr/lib/ckan/default/bin/activate
-
-2. Install the ckanext-s3filestore Python package into your virtual environment::
-
-     pip install ckanext-s3filestore
-
-3. Add ``s3filestore`` to the ``ckan.plugins`` setting in your CKAN
-   config file (by default the config file is located at
-   ``/etc/ckan/default/ckan.ini``).
-
-4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu::
-
-     sudo service apache2 reload
+See the `CKAN Documentation <http://docs.ckan.org>`_ for installation instructions.
 
 
----------------
-Config Settings
----------------
+Support
+-------
+If you need help with CKAN or want to ask a question, use either the
+`ckan-dev`_ mailing list, the `CKAN chat on Gitter`_, or the `CKAN tag on Stack Overflow`_ (try
+searching the Stack Overflow and ckan-dev `archives`_ for an answer to your
+question first).
 
-Required::
+If you've found a bug in CKAN, open a new issue on CKAN's `GitHub Issues`_ (try
+searching first to see if there's already an issue for your bug).
 
-    ckanext.s3filestore.aws_bucket_name = a-bucket-to-store-your-stuff
-    ckanext.s3filestore.region_name= region-name
-    ckanext.s3filestore.signature_version = s3v4
+If you find a potential security vulnerability please email security@ckan.org,
+rather than creating a public issue on GitHub.
 
-Conditional::
-
-    ckanext.s3filestore.aws_access_key_id = Your-Access-Key-ID
-    ckanext.s3filestore.aws_secret_access_key = Your-Secret-Access-Key
-
-    Or:
-
-    ckanext.s3filestore.aws_use_ami_role = true
-
-Optional::
-
-    # An optional path to prepend to keys
-    ckanext.s3filestore.aws_storage_path = my-site-name
-
-    # An optional setting to fallback to filesystem for downloads
-    ckanext.s3filestore.filesystem_download_fallback = true
-    # The ckan storage path option must also be set correctly for the fallback to work
-    ckan.storage_path = path/to/storage/directory
-
-    # An optional setting to change the acl of the uploaded files. Default public-read.
-    ckanext.s3filestore.acl = private
-
-    # An optional setting to specify which addressing style to use. This controls whether the bucket name is in the hostname or is part of the URL. Default auto.
-    ckanext.s3filestore.addressing_style = path
-
-    # Set this parameter only if you want to use Minio as a filestore service instead of S3.
-    ckanext.s3filestore.host_name = http://minio-service.com
-
-    # To mask the S3 endpoint with your own domain/endpoint when serving URLs to end users.
-    # This endpoint should be capable of serving S3 objects as if it were an actual bucket.
-    # The real S3 endpoint will still be used for uploading files.
-    ckanext.s3filestore.download_proxy = https://example.com/my-bucket
-
-    # Defines how long a signed URL is valid (default 1 hour).
-    ckanext.s3filestore.signed_url_expiry = 3600
-
-    # Don't check for access on each startup
-    ckanext.s3filestore.check_access_on_startup = false
+.. _CKAN tag on Stack Overflow: http://stackoverflow.com/questions/tagged/ckan
+.. _archives: https://groups.google.com/a/ckan.org/g/ckan-dev
+.. _GitHub Issues: https://github.com/ckan/ckan/issues
+.. _CKAN chat on Gitter: https://gitter.im/ckan/chat
 
 
------------------
-CLI
------------------
+Contributing to CKAN
+--------------------
 
-To upload all local resources located in `ckan.storage_path` location dir to the configured S3 bucket use::
+For contributing to CKAN or its documentation, see
+`CONTRIBUTING <https://github.com/ckan/ckan/blob/master/CONTRIBUTING.md>`_.
 
-    ckan -c /etc/ckan/default/ckan.ini s3-upload
+Mailing List
+~~~~~~~~~~~~
 
+Subscribe to the `ckan-dev`_ mailing list to receive news about upcoming releases and
+future plans as well as questions and discussions about CKAN development, deployment, etc.
 
-------------------------
-Development Installation
-------------------------
+Community Chat
+~~~~~~~~~~~~~~
 
-To install ckanext-s3filestore for development, activate your CKAN virtualenv and
-do::
+If you want to talk about CKAN development say hi to the CKAN developers and members of
+the CKAN community on the public `CKAN chat on Gitter`_. Gitter is free and open-source;
+you can sign in with your GitHub, GitLab, or Twitter account.
 
-    git clone https://github.com/okfn/ckanext-s3filestore.git
-    cd ckanext-s3filestore
-    python setup.py develop
-    pip install -r dev-requirements.txt
-    pip install -r requirements.txt
+The logs for the old `#ckan`_ IRC channel (2014 to 2018) can be found here:
+https://github.com/ckan/irc-logs.
 
+Wiki
+~~~~
 
------------------
-Running the Tests
------------------
+If you've figured out how to do something with CKAN and want to document it for
+others, make a new page on the `CKAN wiki`_ and tell us about it on the
+ckan-dev mailing list or on Gitter.
 
-To run the tests, do::
-
-    nosetests --ckan --nologcapture --with-pylons=test.ini
-
-To run the tests and produce a coverage report, first make sure you have
-coverage installed in your virtualenv (``pip install coverage``) then run::
-
-    nosetests --ckan --nologcapture --with-pylons=test.ini --with-coverage --cover-package=ckanext.s3filestore --cover-inclusive --cover-erase --cover-tests
+.. _ckan-dev: https://groups.google.com/a/ckan.org/forum/#!forum/ckan-dev
+.. _#ckan: http://webchat.freenode.net/?channels=ckan
+.. _CKAN Wiki: https://github.com/ckan/ckan/wiki
+.. _CKAN chat on Gitter: https://gitter.im/ckan/chat
 
 
----------------------------------------
-Registering ckanext-s3filestore on PyPI
----------------------------------------
+Copying and License
+-------------------
 
-ckanext-s3filestore should be available on PyPI as
-https://pypi.python.org/pypi/ckanext-s3filestore. If that link doesn't work, then
-you can register the project on PyPI for the first time by following these
-steps:
+This material is copyright (c) 2006-2018 Open Knowledge Foundation and contributors.
 
-1. Create a source distribution of the project::
+It is open and licensed under the GNU Affero General Public License (AGPL) v3.0
+whose full text may be found at:
 
-     python setup.py sdist
-
-2. Register the project::
-
-     python setup.py register
-
-3. Upload the source distribution to PyPI::
-
-     python setup.py sdist upload
-
-4. Tag the first release of the project on GitHub with the version number from
-   the ``setup.py`` file. For example if the version number in ``setup.py`` is
-   0.0.1 then do::
-
-       git tag 0.0.1
-       git push --tags
-
-
-----------------------------------------------
-Releasing a New Version of ckanext-s3filestore
-----------------------------------------------
-
-ckanext-s3filestore is available on PyPI as https://pypi.python.org/pypi/ckanext-s3filestore.
-To publish a new version to PyPI follow these steps:
-
-1. Update the version number in the ``setup.py`` file.
-   See `PEP 440 <http://legacy.python.org/dev/peps/pep-0440/#public-version-identifiers>`_
-   for how to choose version numbers.
-
-2. Create a source distribution of the new version::
-
-     python setup.py sdist
-
-3. Upload the source distribution to PyPI::
-
-     python setup.py sdist upload
-
-4. Tag the new release of the project on GitHub with the version number from
-   the ``setup.py`` file. For example if the version number in ``setup.py`` is
-   0.0.2 then do::
-
-       git tag 0.0.2
-       git push --tags
+http://www.fsf.org/licensing/licenses/agpl-3.0.html

--- a/ckanext/s3filestore/fantastic/scripts/resource.config
+++ b/ckanext/s3filestore/fantastic/scripts/resource.config
@@ -1,0 +1,9 @@
+[depends]
+
+main = base/main
+
+[groups]
+
+main =
+    s3filestore-chunked-upload.js
+

--- a/ckanext/s3filestore/fantastic/scripts/s3filestore-chunked-upload.js
+++ b/ckanext/s3filestore/fantastic/scripts/s3filestore-chunked-upload.js
@@ -1,0 +1,379 @@
+ckan.module("s3filestore-multipart-upload", function($, _) {
+    "use strict";
+
+    return {
+        options: {
+            cloud: "S3",
+            filePartMaxSize: 0,
+            fileMaxSize: 0,
+            i18n: {
+                resource_create: _("Resource has been created."),
+                resource_update: _("Resource has been updated."),
+                undefined_upload_id: _("Undefined uploadId."),
+                upload_completed: _(
+                    "Upload completed. You will be redirected in few seconds..."
+                ),
+                unable_to_finish: _("Unable to finish multipart upload")
+            }
+        },
+
+        _partNumber: 0,
+        _s3UploadId: null,
+        _uploadId: null,
+        _packageId: null,
+        _resourceId: null,
+        _uploadSize: null,
+        _uploadName: null,
+        _uploadedParts: null,
+        _clickedBtn: null,
+        _redirect_url: null,
+        _signedUrls: null,
+        _originalFileSize: null,
+        _parts: new Array(),
+        _blobs: new Array(),
+        _fileParts: new Array(),
+        _blobSlice: null,
+
+        initialize: function() {
+            $.proxyAll(this, /_on/);
+            this._blobSlice = $.support.blobSlice && function () {
+                const slice = this.slice || this.webkitSlice || this.mozSlice;
+                return slice.apply(this, arguments);
+            }
+            // There is an undescore as a prefix added to package ID in
+            // order to prevent type-coercion, so we have to strip it
+            this.options.packageId = this.options.packageId.slice(1);
+            this._form = this.$("form");
+            this._file = $("#field-image-upload");
+            this._url = $("#field-image-url");
+            this._save = $("[name=save]");
+            this._id = $("input[name=id]");
+            this._progress = $("<div>", {
+                class: "progress"
+            });
+
+            this._bar = $("<div>", {
+                class: "progress-bar progress-bar-striped progress-bar-animated active"
+            });
+            this._progress.append(this._bar);
+            this._progress.insertAfter(this._url.parent().parent());
+            this._progress.hide();
+
+            this._resumeBtn = $("<a>", { class: "btn btn-info controls" })
+                .insertAfter(this._progress)
+                .text("Resume Upload");
+            this._resumeBtn.hide();
+
+            this._save.on("click", this._onSaveClick);
+
+            (function blink() {
+                $(".upload-message")
+                    .fadeOut(500)
+                    .fadeIn(500, blink);
+            })();
+        },
+
+        _onSaveClick: function(event, pass) {
+            if (pass || !window.FileList || !this._file || !this._file.val()) {
+                return;
+            }
+            event.preventDefault();
+            const dataset_id = this.options.packageId;
+            this._clickedBtn = $(event.target).attr("value");
+            if (this._clickedBtn == "go-dataset") {
+                this._onDisableSave(false);
+                this._redirect_url = this.sandbox.url("/dataset/edit/" + dataset_id);
+                window.location = this._redirect_url;
+            } else {
+                try {
+                    $("html, body").animate({ scrollTop: 0 }, "50");
+                    this._onSaveForm();
+                } catch (error) {
+                    console.error(error);
+                    this._onDisableSave(false);
+                    this._onDisableRemove(false);
+                }
+            }
+        },
+
+        _onFormatBytes(bytes, decimals=2){
+            if (bytes === 0) return '0 Bytes';
+
+            const k = 1024;
+            const dm = decimals < 0 ? 0 : decimals;
+            const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+            const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+            return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+
+        },
+
+        _onSaveForm: function() {
+            const file = this._file[0].files[0];
+            const self = this;
+            // Check if file size is above the max allowed limit.
+            if (this.options.fileMaxSize && !isNaN(parseInt(this.options.fileMaxSize))) {
+                const max_size = parseInt(this.options.fileMaxSize);
+                if (file.size > max_size) {
+                    this._file.val("");
+                    this._onCleanUpload();
+                    self.sandbox.notify(
+                        "Large file:",
+                        "You selected a file larger than " +
+                        self._onFormatBytes(max_size) +
+                        ". Contact support for an alternative upload method or select a smaller one.",
+                        "error"
+                    );
+                    throw "Large file";
+                }
+            }
+            $('.alert-error').remove();
+            this._setProgressType("info", this._bar);
+            this._progress.show("slow");
+            this._setProgress(0, this._bar);
+            this._onDisableSave(true);
+            this._onDisableRemove(true);
+
+            const formData = this._form.serializeArray().reduce(function(result, item) {
+                result[item.name] = item.value;
+                return result;
+            }, {});
+            formData.multipart_name = file.name;
+            formData.url = file.name;
+            formData.package_id = this.options.packageId;
+            formData.size = file.size;
+            formData.url_type = "upload";
+            const action = formData.id ? "resource_update" : "resource_create";
+            self.sandbox.client.call(
+                "POST",
+                action,
+                formData,
+                function(data) {
+                    const result = data.result;
+                    self._packageId = result.package_id;
+                    self._resourceId = result.id;
+
+                    self._id.val(result.id);
+                    self._onPerformChunkedUpload(file);
+                },
+                function(err, st, msg) {
+                    self.sandbox.notify("Error", msg, "error");
+                    self._onHandleError("Unable to save resource");
+                }
+            );
+        },
+
+        _onPerformChunkedUpload: function(file) {
+            const id = this._id.val();
+            const self = this;
+            const originalFileSize = self._originalFileSize = file.size;
+            if (this._uploadId === null)
+                this._onPrepareUpload(file, id).then(
+                    function(data) {
+                        const blobs = self._blobs = [];
+                        let start = 0;
+                        let end, blob;
+                        if (start > file.size) {
+                            this._onFinishUpload();
+                            return;
+                        }
+                        while(start < file.size) {
+                            start = self.options.filePartMaxSize  * self._partNumber++
+                            end = Math.min(start + self.options.filePartMaxSize, file.size);
+                            if (file.slice(start, end).size > 0){
+                                blobs.push(file.slice(start, end, file.type))
+                            }
+                        }
+                        for (let i = 0; i < blobs.length; i++) {
+                            blob = blobs[i];
+                            self._fileParts.push({'url': data.result.signed_urls[i],
+                                'name': file.name,
+                                'uploadId': data.result.id,
+                                'id': id,
+                                'data': blob,
+                                'partNumber': i+1,
+                                'S3uploadId': data.result.upload_id,
+                                'originalFileSize': originalFileSize});
+                        }
+                        self._onSendAllFileParts();
+                    },
+                    function(err) {
+                        console.error(err);
+                        self._onHandleError("Unable to initiate multipart upload");
+                    }
+                );
+        },
+
+        _onSendAllFileParts: function(){
+            const self = this;
+            let progress=0;
+            const parts = new Array();
+            const fileParts = self._fileParts;
+            const name = fileParts[0]['name'];
+            const uploadId = fileParts[0]['uploadId'];
+            const s3UploadId = fileParts[0]['S3uploadId'];
+            for (let i = 0; i < fileParts.length; i++) {
+                if(fileParts[i]['url'] !== undefined) {
+                    const request = self.uploadXHR = new XMLHttpRequest();
+                    if (this._bar.attr("listener") === undefined){
+                        request.upload.addEventListener("progress", function(e){
+                            progress = ((e.loaded / e.total) * 100);
+                            self._setProgress(progress, self._bar);
+                        });
+                        this._bar.attr("listener", "true");
+                    }
+                    request.open('PUT', fileParts[i]['url'], true);
+                    request.setRequestHeader('x-amz-storage-class', 'INTELLIGENT_TIERING')
+                    request.send(fileParts[i]['data']);
+                    request.onload = function() {
+                        // Stitch the file only if there is more than one chunk.
+                        if(fileParts.length > 1) {
+                            const startIndex = request.responseURL.indexOf('partNumber=')+11;
+                            const endIndex = request.responseURL.indexOf('&uploadId')
+                            const partNumber = request.responseURL.substr(startIndex, endIndex-startIndex)
+                            parts.push({'ETag': JSON.parse(request.getResponseHeader('ETag')), 'PartNumber': parseInt(partNumber) })
+                            // Call API to stitch the parts
+                            if(parts.length === fileParts.length){
+                                const data_dict = {
+                                    resourceId: uploadId,
+                                    name: name,
+                                    S3uploadId: s3UploadId,
+                                    parts: parts
+                                };
+                                self.sandbox.client.call(
+                                    "POST",
+                                    "s3filestore_finish_multipart",
+                                    data_dict,
+                                    function(data) {
+                                        if (uploadId) {
+                                            self._onFinishUpload();
+                                        }
+                                    },
+                                    function(err) {
+                                        console.error(err);
+                                        self._onHandleError(self.i18n("Unable to complete multipart upload"));
+                                    }
+                                );
+                            }
+                        }
+                        else{
+                            self._onFinishUpload();
+                        }
+
+                    }
+                    request.onerror = function() {
+                        self._onHandleError("Error uploading file.")
+                    }
+                }
+            }
+
+
+        },
+
+        _onPrepareUpload: function(file, id) {
+            return $.ajax({
+                method: "POST",
+                url: this.sandbox.client.url(
+                    "/api/action/s3filestore_initiate_multipart"
+                ),
+                data: JSON.stringify({
+                    id: id,
+                    name: encodeURIComponent(file.name),
+                    fileSize: file.size,
+                    type: file.type
+                })
+            });
+        },
+
+        _onAbortUpload: function(id) {
+            const self = this;
+            this.sandbox.client.call(
+                "POST",
+                "s3filestore_abort_multipart",
+                {
+                    id: id
+                },
+                function(data) {
+                    console.log(data);
+                },
+                function(err) {
+                    console.error(err);
+                    self._onHandleError("Unable to abort multipart upload");
+                }
+            );
+        },
+
+        _onFinishUpload: function() {
+            const self = this;
+            self._setProgress(100, self._bar);
+            self._progress.hide("fast");
+            self._onDisableSave(false);
+            self.sandbox.notify(
+                "Success",
+                self.i18n("upload_completed"),
+                "success"
+            );
+            // self._form.remove();
+            if(this._clickedBtn === "again") {
+                this._redirect_url = self.sandbox.url(
+                    "/dataset/new_resource/" + self._packageId
+                );
+            } else {
+                self._redirect_url = self.sandbox.url(
+                    "/dataset/" + self._packageId
+                );
+            }
+            self._form.attr("action", self._redirect_url);
+            self._form.attr("method", "GET");
+            self.$("[name]").attr("name", null);
+            setTimeout(function() {
+                self._form.submit();
+            }, 2000);
+        },
+
+        _onDisableSave: function(value) {
+            this._save.attr("disabled", value);
+        },
+
+        _onDisableRemove: function(value) {
+            $(".btn-remove-url").attr("disabled", value);
+            if (value) {
+                $(".btn-remove-url").off();
+            } else {
+                $(".btn-remove-url").on();
+            }
+        },
+
+        _setProgress: function(progress, bar) {
+            bar.css("width", progress + "%");
+        },
+
+        _setProgressType: function(type, bar) {
+            bar
+                .removeClass("bg-success bg-info bg-warning bg-danger")
+                .addClass("bg-" + type);
+        },
+
+        _onHandleError: function(msg) {
+            const self = this;
+            const dict = {'id': this._resourceId}
+            this.sandbox.notify("Error", msg, "error");
+            // this.sandbox.client.call(
+            //     "POST",
+            //     "resource_delete",
+            //     dict,
+            //     function(data) {},
+            //     function(err) {
+            //         self.sandbox.notify("Error", "Unable to rollback resource: "+this._resourceId, "error");
+            //     }
+            //
+            // )
+            this._onDisableSave(false);
+        },
+
+        _onCleanUpload: function() {
+            this.$(".btn-remove-url").trigger("click");
+        }
+    };
+});

--- a/ckanext/s3filestore/fantastic/scripts/s3filestore-chunked-upload.js
+++ b/ckanext/s3filestore/fantastic/scripts/s3filestore-chunked-upload.js
@@ -224,7 +224,10 @@ ckan.module("s3filestore-multipart-upload", function($, _) {
                         this._bar.attr("listener", "true");
                     }
                     request.open('PUT', fileParts[i]['url'], true);
-                    request.setRequestHeader('x-amz-storage-class', 'INTELLIGENT_TIERING')
+                    // Apply this header only if the file is not a chunked upload.
+                    if (fileParts.length === 1) {
+                        request.setRequestHeader('x-amz-storage-class', 'INTELLIGENT_TIERING')
+                    }
                     request.send(fileParts[i]['data']);
                     request.onload = function() {
                         // Stitch the file only if there is more than one chunk.

--- a/ckanext/s3filestore/fantastic/scripts/webassets.yml
+++ b/ckanext/s3filestore/fantastic/scripts/webassets.yml
@@ -1,0 +1,8 @@
+main:
+  filters: rjsmin
+  output: s3filestore/%(version)s_main.js
+  extra:
+    preload:
+      - base/main
+  contents:
+    - s3filestore-chunked-upload.js

--- a/ckanext/s3filestore/helpers.py
+++ b/ckanext/s3filestore/helpers.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import ckan.plugins.toolkit as tk
+
+
+# AWS supports generating only upto 1000 pre-signed urls at one time.
+def max_file_upload_size():
+    return tk.config.get("ckanext.s3filestore.max_file_upload_size_in_bytes", 10737418240)
+
+
+# AWS supports upto 5GB in a single PUT and this value should not be greater.
+def max_file_part_size():
+    return tk.config.get("ckanext.s3filestore.max_file_part_size_in_bytes", 4294967296)

--- a/ckanext/s3filestore/logic/action/__init__.py
+++ b/ckanext/s3filestore/logic/action/__init__.py
@@ -1,0 +1,9 @@
+from ckanext.s3filestore.logic.action import multipart
+
+
+def get_actions():
+    return {
+        "s3filestore_initiate_multipart": multipart.initiate_multipart,
+        "s3filestore_upload_multipart": multipart.upload_multipart,
+        "s3filestore_finish_multipart": multipart.finish_multipart
+    }

--- a/ckanext/s3filestore/logic/action/multipart.py
+++ b/ckanext/s3filestore/logic/action/multipart.py
@@ -52,24 +52,26 @@ def initiate_multipart(context, data_dict):
         chunk_count = math.floor(chunk_count) + 1
     key = 'resources/{0}/{1}'.format(id, name)
     upload_id = uploader.create_multipart_upload_id(key).get('upload_id', '')
-    log.debug('Number of presgined urls to create : {0}'.format(chunk_count))
-    # Use Presgined URLs with multipart upload for files bigger than 4GB
-    # Else Use Presigned URLs for file sizes less than 4GB
+    log.debug('Number of pre-signed urls to create : {0}'.format(chunk_count))
+    # Use Pre-signed URLs with multipart upload for files bigger than 4GB
+    # Else Use Pre-signed URLs for file sizes less than 4GB
     if chunk_count > 1:
         part_count = 1
         while chunk_count >= 1:
-            presigned_urls\
+            presigned_urls \
                 .append(uploader.create_multipart_upload_part(key=key,
                                                               part_number=part_count,
                                                               upload_id=upload_id)
-                .get('url', None))
+                        .get('url', None))
             part_count += 1
             chunk_count -= 1
     else:
         log.debug('File chunk size is not bigger than : {0}'.format(config.get('ckanext.s3filestore.file.chunk_size_in_bytes', "4294967296")))
         key = 'resources/{0}/'.format(id) + munge.munge_filename('{0}'.format(name))
         log.debug('Creating sigv4 with key: {0}'.format(key))
-        presigned_urls.append(uploader.get_signed_url_to_key_for_upload('put_object', key))
+        presigned_urls.append(uploader.get_signed_url_to_key_for_upload('put_object',
+                                                                        key,
+                                                                        {'StorageClass': 'INTELLIGENT_TIERING'}))
 
     return {"id": id, "name": name, "signed_urls": presigned_urls, "upload_id": upload_id}
 

--- a/ckanext/s3filestore/logic/action/multipart.py
+++ b/ckanext/s3filestore/logic/action/multipart.py
@@ -1,0 +1,122 @@
+import logging
+import math
+import operator
+
+import ckan.lib.helpers as h
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+import ckan.lib.munge as munge
+from ckantoolkit import config
+from ckan.lib.uploader import get_resource_uploader
+
+from ckanext.s3filestore.uploader import S3ResourceUploader
+
+log = logging.getLogger(__name__)
+
+
+def initiate_multipart(context, data_dict):
+    """Initiate new Multipart Upload.
+
+    :param context:
+    :param data_dict: dict with required keys:
+        id: resource's id
+        name: filename
+        size: filesize
+
+    :returns: ObjectWith SignedUrls info
+    :rtype: dict
+
+    """
+    h.check_access("s3filestore_initiate_multipart", data_dict)
+    # File parts of 5GB to save generating many presigned urlsG
+    # S3 min file size is 5MB and max 5GB
+    presigned_urls = []
+    file_chunk_size = config.get('ckanext.s3filestore.max_file_part_size_in_bytes', 4294967296)
+    id, name, file_size, file_type = toolkit.get_or_bust(data_dict, ["id", "name", "fileSize", "type"])
+    log.debug('File Type : {0}'.format(file_type))
+    log.debug('The upload file is of size : {0}'.format(file_size))
+    uploader = get_resource_uploader({"multipart_name": name, "id": id})
+    if not isinstance(uploader, S3ResourceUploader):
+        raise toolkit.ValidationError(
+            {
+                "uploader": [
+                    "Must be S3ResourceUploader or its subclass, not"
+                    f" {type(uploader)}"
+                ]
+            }
+        )
+    chunk_count = file_size/int(file_chunk_size)
+    if chunk_count > 1:
+        chunk_count = math.ceil(chunk_count)
+    else:
+        chunk_count = math.floor(chunk_count) + 1
+    key = 'resources/{0}/{1}'.format(id, name)
+    upload_id = uploader.create_multipart_upload_id(key).get('upload_id', '')
+    log.debug('Number of presgined urls to create : {0}'.format(chunk_count))
+    # Use Presgined URLs with multipart upload for files bigger than 4GB
+    # Else Use Presigned URLs for file sizes less than 4GB
+    if chunk_count > 1:
+        part_count = 1
+        while chunk_count >= 1:
+            presigned_urls\
+                .append(uploader.create_multipart_upload_part(key=key,
+                                                              part_number=part_count,
+                                                              upload_id=upload_id)
+                .get('url', None))
+            part_count += 1
+            chunk_count -= 1
+    else:
+        log.debug('File chunk size is not bigger than : {0}'.format(config.get('ckanext.s3filestore.file.chunk_size_in_bytes', "4294967296")))
+        key = 'resources/{0}/'.format(id) + munge.munge_filename('{0}'.format(name))
+        log.debug('Creating sigv4 with key: {0}'.format(key))
+        presigned_urls.append(uploader.get_signed_url_to_key_for_upload('put_object', key))
+
+    return {"id": id, "name": name, "signed_urls": presigned_urls, "upload_id": upload_id}
+
+
+def upload_multipart(context, data_dict):
+    h.check_access("s3filestore_upload_multipart", data_dict)
+    upload_id, part_number, part_content = toolkit.get_or_bust(
+        data_dict, ["uploadId", "partNumber", "upload"]
+    )
+
+    upload = model.Session.query(MultipartUpload).get(upload_id)
+    uploader = get_resource_uploader({"id": upload.resource_id})
+
+    data = _get_underlying_file(part_content).read()
+    resp = uploader.driver.connection.request(
+        _get_object_url(uploader, upload.name),
+        params={"uploadId": upload_id, "partNumber": part_number},
+        method="PUT",
+        headers={"Content-Length": len(data)},
+        data=data,
+    )
+    if resp.status != 200:
+        raise toolkit.ValidationError("Upload failed: part %s" % part_number)
+
+    _save_part_info(part_number, resp.headers["etag"], upload)
+    return {"partNumber": part_number, "ETag": resp.headers["etag"]}
+
+
+def finish_multipart(context, data_dict):
+    log.debug('Called from inside s3filestore_finish_multipart')
+    h.check_access("s3filestore_finish_multipart", data_dict)
+    parts_list = data_dict['parts']
+    parts_list.sort(key=lambda x: x.get('PartNumber'))
+    resource_id, name, s3_upload_id = toolkit.get_or_bust(data_dict, ["resourceId", "name", "S3uploadId"])
+    uploader = get_resource_uploader({"multipart_name": name, "id": resource_id})
+    if not isinstance(uploader, S3ResourceUploader):
+        raise toolkit.ValidationError(
+            {
+                "uploader": [
+                    "Must be S3ResourceUploader or its subclass, not"
+                    f" {type(uploader)}"
+                ]
+            }
+        )
+    key = 'resources/{0}/{1}'.format(resource_id, name)
+    log.debug('Resource Name: {0}'.format(key))
+    complete = uploader.complete_multipart_upload(key, parts_list, s3_upload_id)
+
+    return {"commited": True}
+

--- a/ckanext/s3filestore/logic/auth/__init__.py
+++ b/ckanext/s3filestore/logic/auth/__init__.py
@@ -1,0 +1,12 @@
+from ckanext.s3filestore.logic.auth import multipart
+
+
+def get_auth_functions():
+    return {
+        "s3filestore_initiate_multipart": multipart.initiate_multipart,
+        "s3filestore_upload_multipart": multipart.upload_multipart,
+        "s3filestore_finish_multipart": multipart.finish_multipart,
+        "s3filestore_abort_multipart": multipart.abort_multipart,
+        "s3filestore_check_multipart": multipart.check_multipart,
+        "s3filestore_clean_multipart": multipart.clean_multipart,
+    }

--- a/ckanext/s3filestore/logic/auth/multipart.py
+++ b/ckanext/s3filestore/logic/auth/multipart.py
@@ -1,0 +1,25 @@
+from ckan.logic import check_access
+
+
+def initiate_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
+def upload_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
+def finish_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
+def abort_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
+def check_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
+def clean_multipart(context, data_dict):
+    return {"success": False}

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -3,25 +3,38 @@ import ckan.plugins as plugins
 import ckantoolkit as toolkit
 
 import ckanext.s3filestore.uploader
+from ckanext.s3filestore.logic.action import get_actions
+from ckanext.s3filestore.logic.auth import get_auth_functions
 from ckanext.s3filestore.views import resource, uploads
 from ckanext.s3filestore.click_commands import upload_resources
+from ckanext.s3filestore import helpers
+import ckan.lib.munge as munge
 
 
 class S3FileStorePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)
+    plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IAuthFunctions)
+    plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IUploader)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IClick)
     plugins.implements(plugins.IResourceController, inherit=True)
+
     # IConfigurer
 
     def update_config(self, config_):
+        # We need to register the following templates dir
         toolkit.add_template_directory(config_, 'templates')
-        # We need to register the following templates dir in order
-        # to fix downloading the HTML file instead of previewing when
-        # 'webpage_view' is enabled
-        toolkit.add_template_directory(config_, 'theme/templates')
+        toolkit.add_resource("fantastic/scripts", "s3filestore-js")
+
+    # ITemplateHelpers
+    def get_helpers(self):
+        return dict(
+            s3filestore_max_file_upload_size_in_bytes=helpers.max_file_upload_size,
+            s3filestore_max_file_part_size_in_bytes=helpers.max_file_part_size,
+        )
 
     # IConfigurable
 
@@ -50,6 +63,16 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
             ckanext.s3filestore.uploader.BaseS3Uploader().get_s3_bucket(
                 config.get('ckanext.s3filestore.aws_bucket_name'))
 
+    # IActions
+
+    def get_actions(self):
+        return get_actions()
+
+    # IAuthFunctions
+
+    def get_auth_functions(self):
+        return get_auth_functions()
+
     # IUploader
 
     def get_resource_uploader(self, data_dict):
@@ -64,7 +87,7 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
     # IBlueprint
 
     def get_blueprint(self):
-        blueprints = resource.get_blueprints() +\
+        blueprints = resource.get_blueprints() + \
                      uploads.get_blueprints()
         return blueprints
 
@@ -74,6 +97,9 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         return [upload_resources]
 
     # IResourceController
+    def before_create(self, context, resource):
+        filename = munge.munge_filename(resource.get('name'))
+        resource['name'] = filename
 
     def before_delete(self, context, resource, resources):
         # let's get all info about our resource. It somewhere in resources

--- a/ckanext/s3filestore/templates/package/new_resource.html
+++ b/ckanext/s3filestore/templates/package/new_resource.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block form %}
+    {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
+    {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
+    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+{% endblock %}
+
+

--- a/ckanext/s3filestore/templates/package/new_resource_not_draft.html
+++ b/ckanext/s3filestore/templates/package/new_resource_not_draft.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block form %}
+    {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
+    {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
+    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+{% endblock %}
+
+

--- a/ckanext/s3filestore/templates/package/resource_edit.html
+++ b/ckanext/s3filestore/templates/package/resource_edit.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block form %}
+    {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
+    {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
+    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+{% endblock %}
+
+

--- a/ckanext/s3filestore/templates/snippets/multipart_module.html
+++ b/ckanext/s3filestore/templates/snippets/multipart_module.html
@@ -1,0 +1,11 @@
+{% asset 's3filestore-js/main' %}
+<div
+    data-module="s3filestore-multipart-upload"
+    data-module-cloud='S3'
+    data-module-package-id="_{{ pkg_name }}"
+    data-module-file-part-max-size="{{ file_part_max_size }}"
+    data-module-file-max-size="{{ file_max_size }}"
+>
+    {{ parent() }}
+
+</div>

--- a/ckanext/s3filestore/uploader.py
+++ b/ckanext/s3filestore/uploader.py
@@ -186,7 +186,7 @@ class BaseS3Uploader(object):
 
     def get_signed_url_to_key_for_upload(self, method, key, extra_params={}):
         client = self.get_s3_client()
-        params = {'Bucket': self.bucket_name, 'Key': key, 'StorageClass': 'INTELLIGENT_TIERING'}
+        params = {'Bucket': self.bucket_name, 'Key': key}
         params.update(extra_params)
         url = client.generate_presigned_url(ClientMethod=method,
                                             Params=params,
@@ -196,6 +196,7 @@ class BaseS3Uploader(object):
     def create_multipart_upload_id(self, key):
         client = self.get_s3_client()
         mpu = client.create_multipart_upload(Bucket=self.bucket_name,
+                                             StorageClass='INTELLIGENT_TIERING',
                                              Key=key)
         log.debug('Created the multipart upload with id: {0}'.format(mpu['UploadId']))
 
@@ -206,7 +207,7 @@ class BaseS3Uploader(object):
         url = self.get_signed_url_to_key_for_upload(method='upload_part',
                                                     key=key,
                                                     extra_params={'PartNumber': part_number,
-                                                                  'UploadId':upload_id})
+                                                                  'UploadId': upload_id})
         return {'url': url}
 
     def complete_multipart_upload(self, key, parts, upload_id):


### PR DESCRIPTION
**Context:**
Larger files would have an issue while uploading into S3, even though the AWS SDK is configured to upload using `multipart-uploads` PaloAlto/Cloudfront configuration would return a `504 - Gateway Timeout`. 

You can read more about it [here](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-504-gateway-timeout.html)

**This version Supports**

- Uploading to S3 directly, bypasses buffering file content into CKAN
- Default values for MaxFileSize and MaxFileChunkSize can be set using CKAN environment variables
- If MaxFileSize < MaxFileChunkSize, we generate pre-signed URL without any `partNumber` parameters appended into the URL. This also means the uploaded file will not have to call the AWS `complete_multipart_upload` action to have different parts stitched back together.
- By default presgined-urls for uploading will be set to store content with `INTELLIGENT_TEIRING` into S3
- Migration command s3-upload support `start` and `end` configuration to retry any broken or incomplete migrations that were run.
- All S3 bucket configuration is added as a part of JIRA ticket `84` re-adding it here for redundancy 
 Added an extra HEADER `x-amz-storage-class` to support pushing files into S3 `INTELLEGENT_TEIRING`

**CORS S3 Bucket Policy:**
```
[
    {
        "AllowedHeaders": [
            "*"
        ],
        "AllowedMethods": [
            "GET",
            "PUT"
        ],
        "AllowedOrigins": [
            "<your-supported-domains>"
        ],
        "ExposeHeaders": [
            "ETag",
            "x-amz-request-id",
            "x-amz-storage-class"
        ],
        "MaxAgeSeconds": 3000
    }
]
```

