### PR TITLE
Keep connection alive to allow for larger files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,19 @@ As chunked files are to be stitched together using the (finish_multipart) CKAN a
 
 Server session timeout is to be considered as a factor to decide upper thresholds for file size and chunk size
 
+------------
+Keep Connection to Server Alive:
+------------
+
+This setting will be used to keep a connection to the server alive, when uploading larger files.
+
+Default value is set to 15 minutes (900000ms)
+And should not be set lower than 1 minute (60000)
+
+
+Config Param::
+
+    ckanext.s3filestore.session_timeout_in_ms=90000
 
 ------------
 Requirements

--- a/ckanext/s3filestore/helpers.py
+++ b/ckanext/s3filestore/helpers.py
@@ -11,3 +11,8 @@ def max_file_upload_size():
 # AWS supports upto 5GB in a single PUT and this value should not be greater.
 def max_file_part_size():
     return tk.config.get("ckanext.s3filestore.max_file_part_size_in_bytes", 4294967296)
+
+
+# CKAN Session Timeout Value
+def ckan_session_timeout_ms():
+    return tk.config.get("ckanext.s3filestore.ckan_session_timeout_in_ms", 900000)

--- a/ckanext/s3filestore/logic/action/__init__.py
+++ b/ckanext/s3filestore/logic/action/__init__.py
@@ -5,5 +5,6 @@ def get_actions():
     return {
         "s3filestore_initiate_multipart": multipart.initiate_multipart,
         "s3filestore_upload_multipart": multipart.upload_multipart,
-        "s3filestore_finish_multipart": multipart.finish_multipart
+        "s3filestore_finish_multipart": multipart.finish_multipart,
+        "s3filestore_keep_alive_multipart": multipart.keep_alive_multipart
     }

--- a/ckanext/s3filestore/logic/action/multipart.py
+++ b/ckanext/s3filestore/logic/action/multipart.py
@@ -122,3 +122,6 @@ def finish_multipart(context, data_dict):
 
     return {"commited": True}
 
+
+def keep_alive_multipart(context, data_dict):
+    return {"keep_alive": True}

--- a/ckanext/s3filestore/logic/auth/__init__.py
+++ b/ckanext/s3filestore/logic/auth/__init__.py
@@ -6,6 +6,7 @@ def get_auth_functions():
         "s3filestore_initiate_multipart": multipart.initiate_multipart,
         "s3filestore_upload_multipart": multipart.upload_multipart,
         "s3filestore_finish_multipart": multipart.finish_multipart,
+        "s3filestore_keep_alive_multipart": multipart.keep_alive_multipart,
         "s3filestore_abort_multipart": multipart.abort_multipart,
         "s3filestore_check_multipart": multipart.check_multipart,
         "s3filestore_clean_multipart": multipart.clean_multipart,

--- a/ckanext/s3filestore/logic/auth/multipart.py
+++ b/ckanext/s3filestore/logic/auth/multipart.py
@@ -13,6 +13,10 @@ def finish_multipart(context, data_dict):
     return {"success": check_access("resource_create", context, data_dict)}
 
 
+def keep_alive_multipart(context, data_dict):
+    return {"success": check_access("resource_create", context, data_dict)}
+
+
 def abort_multipart(context, data_dict):
     return {"success": check_access("resource_create", context, data_dict)}
 

--- a/ckanext/s3filestore/plugin.py
+++ b/ckanext/s3filestore/plugin.py
@@ -34,6 +34,8 @@ class S3FileStorePlugin(plugins.SingletonPlugin):
         return dict(
             s3filestore_max_file_upload_size_in_bytes=helpers.max_file_upload_size,
             s3filestore_max_file_part_size_in_bytes=helpers.max_file_part_size,
+            s3filestore_ckan_session_timeout_ms=helpers.ckan_session_timeout_ms,
+
         )
 
     # IConfigurable

--- a/ckanext/s3filestore/templates/package/new_resource.html
+++ b/ckanext/s3filestore/templates/package/new_resource.html
@@ -3,7 +3,13 @@
 {% block form %}
     {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
     {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
-    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+    {% set session_timeout_ms = h.s3filestore_ckan_session_timeout_ms() %}
+    {% snippet 'snippets/multipart_module.html',
+    pkg_name=pkg_name,
+    session_timeout_ms=session_timeout_ms,
+    file_max_size=file_max_size,
+    file_part_max_size=file_part_max_size,
+    parent=super %}
 {% endblock %}
 
 

--- a/ckanext/s3filestore/templates/package/new_resource_not_draft.html
+++ b/ckanext/s3filestore/templates/package/new_resource_not_draft.html
@@ -3,7 +3,13 @@
 {% block form %}
     {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
     {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
-    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+    {% set session_timeout_ms = h.s3filestore_ckan_session_timeout_ms() %}
+    {% snippet 'snippets/multipart_module.html',
+    pkg_name=pkg_name,
+    session_timeout_ms=session_timeout_ms,
+    file_max_size=file_max_size,
+    file_part_max_size=file_part_max_size,
+    parent=super %}
 {% endblock %}
 
 

--- a/ckanext/s3filestore/templates/package/resource_edit.html
+++ b/ckanext/s3filestore/templates/package/resource_edit.html
@@ -3,7 +3,13 @@
 {% block form %}
     {% set file_max_size = h.s3filestore_max_file_upload_size_in_bytes() %}
     {% set file_part_max_size = h.s3filestore_max_file_part_size_in_bytes() %}
-    {% snippet 'snippets/multipart_module.html', pkg_name=pkg_name, file_max_size=file_max_size, file_part_max_size=file_part_max_size, parent=super%}
+    {% set session_timeout_ms = h.s3filestore_ckan_session_timeout_ms() %}
+    {% snippet 'snippets/multipart_module.html',
+    pkg_name=pkg_name,
+    session_timeout_ms=session_timeout_ms,
+    file_max_size=file_max_size,
+    file_part_max_size=file_part_max_size,
+    parent=super %}
 {% endblock %}
 
 

--- a/ckanext/s3filestore/templates/snippets/multipart_module.html
+++ b/ckanext/s3filestore/templates/snippets/multipart_module.html
@@ -3,6 +3,7 @@
     data-module="s3filestore-multipart-upload"
     data-module-cloud='S3'
     data-module-package-id="_{{ pkg_name }}"
+    data-module-session-timeout-ms="{{ session_timeout_ms }}"
     data-module-file-part-max-size="{{ file_part_max_size }}"
     data-module-file-max-size="{{ file_max_size }}"
 >


### PR DESCRIPTION
**Context:**

While uploading larger files, specially with chunked uploads where multiple `pre-signed` urls are used, we want to keep the ckan connection with the client browser alive for the time of the upload.

**Fixes:**

- Added a new ckan configuration parameter `ckanext.s3filestore.ckan_session_timeout_in_ms=90000`
- Default session timeout value is set to 15 minutes
- A `POST` REST api call is made every `15-1 minute(s)` 
- Theoretically speaking we should be able to upload any size files upto the S3 limit for an object which is `5TB`

**Test:**

For development purposes I set the session time out value to `2 Minutes`
Screenshot below shows how an API `s3filestore_keep_alive_multipart` call was made into CKAN every `1 Minute`

![image](https://user-images.githubusercontent.com/103553413/176617896-00779c45-50bf-485c-b00c-e63da90e11a0.png)


**After successful upload**

Notice the `POST` api calls to keep the server connection alive.
Notice how a 2GB `Part-1 PUT` URL
Notice a 1GB `Part-2 PUT` URL have been sent to `S3` directly.

![image](https://user-images.githubusercontent.com/103553413/176619970-71d9af57-e08e-46a0-b3fd-ea40c412e79e.png)


